### PR TITLE
Breakpoint adjustments.

### DIFF
--- a/src/utils/getBreakpoints.js
+++ b/src/utils/getBreakpoints.js
@@ -5,28 +5,35 @@ export default function getBreakpoints(breakpoints, imageWidth) {
     return breakpoints.sort((a, b) => a - b);
   }
 
-  const { count, minWidth, maxWidth } = breakpoints || {};
-
-  let current = minWidth || 320;
-  const max = maxWidth || imageWidth;
-  let n = count || (max < 400 ? 1 : max < 640 ? 2 : 3);
-
-  const diff = max - current;
-  const breakPoints = [];
-  let steps = 0;
-
-  for (let i = 1; i < n; i++) {
-    steps += i;
+  if (imageWidth > 5000) {
+    imageWidth = 5000;
   }
+  const { count, minWidth, maxWidth } = breakpoints || {};
+  let min = minWidth || 320;
+  let max = maxWidth || imageWidth;
 
-  const pixelsPerStep = diff / steps;
+  let steps =
+    count || max < 400
+      ? 1
+      : max < 720
+      ? 2
+      : max < 1300
+      ? 3
+      : max < 1700
+      ? 4
+      : 5;
 
-  n > 1 && breakPoints.push(current);
+  const span = max - min;
+  const breakPoints = [];
 
-  for (let i = 1; i < n - 1; i++) {
-    const next = pixelsPerStep * (n - i) + current;
+  const pixelsPerStep = span / steps;
+  let pixelsFactor = pixelsPerStep / steps;
+  steps > 1 && breakPoints.push(min);
+
+  for (let i = 0; i < steps - 1; i++) {
+    const next = Math.pow(pixelsFactor, i / (10 - i) + 1) + min;
     breakPoints.push(Math.round(next));
-    current = next;
+    min = next;
   }
 
   breakPoints.push(max);


### PR DESCRIPTION
## For more practical speed improvements:

- `const next = Math.pow(pixelsFactor, i / (10 - i) + 1) + min;` line: 34, is to dynamically skew the breakpoints closer to the smaller widths. Will dynamically apply to any width. For example, using an image with original width of `8000px`:

  - Without skew: breakpoints are: `320w, 3392w, 5696w, 7232w, 8000w`.
  - With skew: breakpoints are: `320w, 627w, 1208w, 2494w, 6070w, 8000w`. (with an additional breakpoint because of expanded number)

- Capped `imageWidth` to 5000px, because using more than 5000px is much less common, will give it a little more performance but still can be overridden by maxWidth. This number was a dart throw.

## Other
- Expanded `steps` ternary for more breakpoints for wider images. 
- ```steps``` was calculating in a compounding way. Not sure if or why this was intentional, based on the `for` loop on line 33. Adjusted to accommodate.

- Changed `current` variable name to `min` for clarity.
